### PR TITLE
Agenda Screen - Handle network response at data layer

### DIFF
--- a/app/src/main/java/com/cp/tasky/agenda/overview/data/mapper/AgendaOverviewMapper.kt
+++ b/app/src/main/java/com/cp/tasky/agenda/overview/data/mapper/AgendaOverviewMapper.kt
@@ -1,0 +1,12 @@
+package com.cp.tasky.agenda.overview.data.mapper
+
+import com.cp.tasky.agenda.overview.data.model.OverviewApiResponse
+import com.cp.tasky.agenda.overview.domain.model.Overview
+
+fun OverviewApiResponse.toOverView(): Overview {
+    return Overview(
+        events = events,
+        tasks = tasks,
+        reminders = reminders
+    )
+}

--- a/app/src/main/java/com/cp/tasky/agenda/overview/data/remote/OverviewApi.kt
+++ b/app/src/main/java/com/cp/tasky/agenda/overview/data/remote/OverviewApi.kt
@@ -13,7 +13,7 @@ interface OverviewApi {
     suspend fun getAgendaByDate(@Query("time") time: Long): Response<OverviewApiResponse>
 
     @POST("/syncAgenda")
-    suspend fun syncAgenda(@Body agendaSyncRequest: OverviewSyncRequest)
+    suspend fun syncAgenda(@Body agendaSyncRequest: OverviewSyncRequest): Response<Unit>
 
     @GET("/fullAgenda")
     suspend fun getFullAgenda(): Response<OverviewApiResponse>

--- a/app/src/main/java/com/cp/tasky/agenda/overview/data/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/cp/tasky/agenda/overview/data/remote/RemoteDataSource.kt
@@ -2,30 +2,72 @@ package com.cp.tasky.agenda.overview.data.remote
 
 import com.cp.tasky.agenda.overview.data.model.OverviewApiResponse
 import com.cp.tasky.agenda.overview.data.model.OverviewSyncRequest
+import com.cp.tasky.core.data.util.DataError
 import com.cp.tasky.core.data.util.Error
 import com.cp.tasky.core.data.util.Result
+import retrofit2.Response
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 interface RemoteDataResource {
     suspend fun getAgendaByDate(timeStamp: Long): Result<OverviewApiResponse, Error>
 
-    suspend fun syncAgenda(overviewSyncRequest: OverviewSyncRequest)
+    suspend fun syncAgenda(overviewSyncRequest: OverviewSyncRequest): Result<Unit, Error>
 
     suspend fun getFullAgenda(): Result<OverviewApiResponse, Error>
 }
 
 class RemoteDataSourceImpl @Inject constructor(
-    private val overviewApi: OverviewApi
+    private val overviewApi: OverviewApi,
 ) : RemoteDataResource {
     override suspend fun getAgendaByDate(timeStamp: Long): Result<OverviewApiResponse, Error> {
-        //TODO: Make API request and handle network error
+        return handleApiResponse(
+            apiCall = { overviewApi.getAgendaByDate(timeStamp) },
+            errorHandler = { code ->
+                // TODO: Specific error code will be added once integrating logging
+                if (code in 500..599) DataError.Remote.SERVER_NOT_AVAILABLE
+                else DataError.Remote.UNKNOWN
+            }
+        )
     }
 
-    override suspend fun syncAgenda(overviewSyncRequest: OverviewSyncRequest) {
-        //TODO: Make API request and handle network error
+    override suspend fun syncAgenda(overviewSyncRequest: OverviewSyncRequest): Result<Unit, Error> {
+        return handleApiResponse(
+            apiCall = { overviewApi.syncAgenda(overviewSyncRequest) },
+            errorHandler = { DataError.Remote.UNABLE_TO_SYNC }
+        )
     }
 
     override suspend fun getFullAgenda(): Result<OverviewApiResponse, Error> {
-        //TODO: Make API request and handle network error
+        return handleApiResponse(
+            apiCall = { overviewApi.getFullAgenda() },
+            errorHandler = { code ->
+                // TODO: Specific error code will be added once integrating logging
+                if (code in 500..599) DataError.Remote.SERVER_NOT_AVAILABLE
+                else DataError.Remote.UNKNOWN
+            }
+        )
+    }
+
+    private suspend fun <T> handleApiResponse(
+        apiCall: suspend () -> Response<T>,
+        successHandler: (T) -> Result<T, DataError> = { Result.Success(it) },
+        errorHandler: (Int) -> DataError = { DataError.Remote.UNKNOWN },
+    ): Result<T, DataError> {
+        return try {
+            val response = apiCall()
+
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    successHandler(it)
+                } ?: Result.Error(DataError.Remote.UNKNOWN)
+            } else {
+                Result.Error(errorHandler(response.code()))
+            }
+        } catch (e: Exception) {
+            // Stop coroutine if it get cancelled, or time out
+            if (e is CancellationException) throw e
+            Result.Error(DataError.Remote.UNKNOWN)
+        }
     }
 }

--- a/app/src/main/java/com/cp/tasky/agenda/overview/data/repository/OverviewRepositoryImpl.kt
+++ b/app/src/main/java/com/cp/tasky/agenda/overview/data/repository/OverviewRepositoryImpl.kt
@@ -1,23 +1,50 @@
 package com.cp.tasky.agenda.overview.data.repository
 
+import com.cp.tasky.agenda.overview.data.mapper.toOverView
 import com.cp.tasky.agenda.overview.data.remote.RemoteDataResource
 import com.cp.tasky.agenda.overview.domain.OverviewRepository
 import com.cp.tasky.agenda.overview.domain.model.Overview
-import java.time.LocalDateTime
+import com.cp.tasky.core.data.util.DataError
+import com.cp.tasky.core.data.util.Error
+import com.cp.tasky.core.data.util.Result
+import com.cp.tasky.core.data.util.map
 import javax.inject.Inject
 
 class OverviewRepositoryImpl @Inject constructor(
-    remoteDataResource: RemoteDataResource
-): OverviewRepository {
-    override suspend fun getAgendaByDate(timeStamp: LocalDateTime): Overview {
-        TODO("Not yet implemented")
+    private val remoteDataResource: RemoteDataResource,
+) : OverviewRepository {
+    //TODO: Switching from `Long` to `LocalDataTime/ZonedDataTime` once impl the DatePickerDialog
+    override suspend fun getAgendaByDate(timeStamp: Long): Result<Overview, Error> {
+        // TODO: offline first
+        return when (val agenda = remoteDataResource.getAgendaByDate(timeStamp)) {
+            is Result.Success -> {
+                agenda.map { it.toOverView() }
+            }
+
+            is Result.Error -> {
+                // TODO: fall back to local database if available
+                Result.Error(agenda.error)
+            }
+            else -> Result.Error(DataError.Remote.UNKNOWN)
+        }
     }
 
-    override suspend fun syncAgendaRemotely() {
-        TODO("Not yet implemented")
+    override suspend fun syncAgendaRemotely(): Result<Unit, Error> {
+        // TODO: get overviewSyncRequest from ROOM to sync agenda items with remote database
+        return Result.Loading // temp return value
     }
 
-    override suspend fun getFullAgenda(): Overview {
-        TODO("Not yet implemented")
+    override suspend fun getFullAgenda(): Result<Overview, Error> {
+        return when (val agenda = remoteDataResource.getFullAgenda()) {
+            is Result.Success -> {
+                // TODO: sync device's local cache (ROOM) from remote database
+                agenda.map { it.toOverView() }
+            }
+
+            is Result.Error -> {
+                Result.Error(agenda.error)
+            }
+            else -> Result.Error(DataError.Remote.UNKNOWN)
+        }
     }
 }

--- a/app/src/main/java/com/cp/tasky/agenda/overview/domain/OverviewRepository.kt
+++ b/app/src/main/java/com/cp/tasky/agenda/overview/domain/OverviewRepository.kt
@@ -1,12 +1,13 @@
 package com.cp.tasky.agenda.overview.domain
 
 import com.cp.tasky.agenda.overview.domain.model.Overview
-import java.time.LocalDateTime
+import com.cp.tasky.core.data.util.Error
+import com.cp.tasky.core.data.util.Result
 
 interface OverviewRepository {
-    suspend fun getAgendaByDate(timeStamp: LocalDateTime): Overview
+    suspend fun getAgendaByDate(timeStamp: Long): Result<Overview, Error>
 
-    suspend fun syncAgendaRemotely()
+    suspend fun syncAgendaRemotely(): Result<Unit, Error>
 
-    suspend fun getFullAgenda(): Overview
+    suspend fun getFullAgenda(): Result<Overview, Error>
 }

--- a/app/src/main/java/com/cp/tasky/core/data/util/DataError.kt
+++ b/app/src/main/java/com/cp/tasky/core/data/util/DataError.kt
@@ -5,6 +5,7 @@ sealed interface DataError: Error{
         SERVER_NOT_AVAILABLE,
         UNAUTHORIZED,
         EMAIL_ALREADY_EXIST,
-        UNKNOWN
+        UNKNOWN,
+        UNABLE_TO_SYNC
     }
 }


### PR DESCRIPTION
Handle network response and error at the remote database, instead of repository class because: 

Testability: Interfaces make it easier to mock dependencies in unit tests. This allows you to test the repository logic independently of the actual network calls.

Flexibility and Extensibility: If the way you fetch data changes (e.g., switching from Retrofit to another networking library, or adding caching layers), you can do so without changing the repository’s code. Only the implementation of RemoteDataResource needs to change.

Consistency: Encapsulating network calls within a dedicated data source ensures a consistent approach to network operations across the application. This can include common logging, error handling, or request modification.